### PR TITLE
[Bug] Add the canonical "footer" block

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -8,6 +8,7 @@
     {{ block "header" . }}{{ partial "header.html" . }}{{ end }}
     {{ block "main" . }}{{ end }}
     {{ partial "footer.html" . }}
+    {{ block "footer" . }}{{ end }}
   </body>
 </html>
 


### PR DESCRIPTION
The base template and block system allows easy integration of themes with theme components.

The "footer" blocks is also one of the suggested blocks in the Hugo docs: https://gohugo.io/templates/base/#define-the-base-template.

Add this block quickly enables the use of theme components like [hugo-search-fuse-js](https://github.com/kaushalmodi/hugo-search-fuse-js/). I ended up creating this PR because of an issue created there: https://github.com/kaushalmodi/hugo-search-fuse-js/issues/1.